### PR TITLE
Adding options.format to allowing different ordering of hash and file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function defaultFormat (_path, _hex) {
     return _path + ' ' + _hex;
 }
 
-function hashStream (_path, hash) {
+function hashStream (_path, hash, format) {
     var stream = through.obj(
         function transform (chunk, enc, callback) {
             hash.update(chunk);
@@ -13,7 +13,7 @@ function hashStream (_path, hash) {
         },
 
         function flush (callback) {
-            this.push(format(_path, hash));
+            this.push(format(_path, hash.digest('hex')));
             callback();
         }
     );
@@ -26,7 +26,7 @@ module.exports = function (options) {
 
     if (!options.algo) options.algo = 'md5';
     var format = options.format || defaultFormat;
-
+    
     var stream = through.obj(function (file, inc, callback) {
         var _path = '';
 
@@ -48,7 +48,7 @@ module.exports = function (options) {
         }
 
         if (file.isStream()) {
-            var streamer = hashStream(_path, hash);
+            var streamer = hashStream(_path, hash, format);
             streamer.on('error', this.emit.bind(this, 'error'));
             file.contents = file.contents.pipe(streamer);
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var through = require('through2');
 var crypto = require('crypto');
 
-function format (_path, hash) {
-    return _path + ' ' + hash.digest('hex');
+function defaultFormat (_path, _hex) {
+    return _path + ' ' + _hex;
 }
 
 function hashStream (_path, hash) {
@@ -25,6 +25,7 @@ module.exports = function (options) {
     options = options || {};
 
     if (!options.algo) options.algo = 'md5';
+    var format = options.format || defaultFormat;
 
     var stream = through.obj(function (file, inc, callback) {
         var _path = '';
@@ -40,7 +41,7 @@ module.exports = function (options) {
 
         if (file.isBuffer()) {
 			hash.update(file.contents);
-			file.contents = new Buffer(format(_path, hash));
+			file.contents = new Buffer(format(_path, hash.digest('hex')));
 
             this.push(file);
             return callback();

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,35 @@ mapping of filepaths to their hash separted by newline
 /public/js/file1.js ################################
 ```
 
+
+##Options##
+
+The `hash` command supports the following options
+
+- `options.algo` - which hashing algorithm to use. Examples are `'md5'` (the default) and `'sha1'`. The algorithms available will depend on the version of OpenSSL on your system - see [the node documentation](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm).
+
+- `options.format` - by default, the manifest will formatted as per the example above, with the file followed by the hash. `options.format` is a function which takes the file name and hash as parameters, and returns a string
+
+```
+var gulp = require("gulp"); 
+var hash = require("gulp-hash-manifest");
+var concat = require("gulp-concat");
+
+gulp.task("make-md5-manifest", function() {
+	var path = "build/";
+	var absPath = __dirname + path;
+	var prefixLen = absPath.length + 2;
+	return gulp.src(path + "**/**", {base: path})
+        .pipe(hash({
+			format: function(_path, _hex) {
+				return _hex + " " + _path.substr(prefixLen);
+			}
+		}))
+        .pipe(concat("checksum.md5"))
+        .pipe(gulp.dest(path ));
+});
+```
+
 # License
 
 The MIT License (MIT)


### PR DESCRIPTION
Hi. Thanks for making the module. I've made a change to allow passing in a format function on the options object so that the file and hash strings can be reformatted. This means I can output an md5 file in the format that md5runner understands. I've added the necessary documentation to the readme.
